### PR TITLE
feat(types): Gap type

### DIFF
--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -1,8 +1,7 @@
 import { FC } from 'react';
 import styled from 'styled-components';
 
-import { GAP } from '../../theme/definition';
-import { propValueMap, Justify, Align } from '../../theme/types';
+import { propValueMap, Justify, Align, Gap } from '../../theme/types';
 import { Box, BoxProps, BoxVariant } from '../Box';
 import { Flex, FlexProps, FlexVariant } from '../Flex';
 
@@ -13,7 +12,7 @@ export type GridProps = BoxProps & {
   align?: Align;
   cols?: string;
   rows?: string;
-  gap?: keyof typeof GAP;
+  gap?: Gap;
 };
 
 export type GridItemProps = BoxProps &

--- a/src/theme/definition.ts
+++ b/src/theme/definition.ts
@@ -1,7 +1,7 @@
 import { createGlobalStyle } from 'styled-components';
 
 import * as polyIcons from './icons';
-import { CSSPropertiesExtended } from './types';
+import { CSSPropertiesExtended, Gap } from './types';
 import { BoxVariant } from '../components/Box';
 import { ButtonVariant } from '../components/Button';
 import { IconVariant } from '../components/Icon';
@@ -28,7 +28,7 @@ export const MEDIA_QUERY = {
   xl: `@media (min-width: ${BREAKPOINT.xl}px)`,
 };
 
-export const GAP = {
+export const GAP: Record<Gap, string> = {
   xs: '8px',
   s: '16px',
   m: '24px',

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -35,3 +35,5 @@ export type OptionType = {
   value: string;
   label: string;
 };
+
+export type Gap = 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl' | 'xxxl';


### PR DESCRIPTION
`gap` prop should expect a type of `"xs" | "s" | "m" | "l" | "xl" | "xxl" | "xxxl" | undefined`, any other string will not work.

- added `Gap` type in `theme/types.ts`
- define `GAP` using `Gap` type