### PR TITLE
fix: Correcting Collapsable icon size & adding hasIconBg

### DIFF
--- a/src/components/Collapsable/Collapsable.tsx
+++ b/src/components/Collapsable/Collapsable.tsx
@@ -1,5 +1,4 @@
 import { FC, useState } from 'react';
-
 import { COLLAPSABLE } from '../../theme/definition';
 import { polyIcons } from '../../theme';
 import { Box, BoxVariant, BoxProps } from '../Box';

--- a/src/theme/definition.ts
+++ b/src/theme/definition.ts
@@ -9,7 +9,6 @@ import { TextVariant } from '../components/Text';
 import { BadgeVariant } from '../components/Badge';
 import { InfoBoxVariant } from '../components/InfoBox';
 import { DrawerVariant } from '../components/Drawer';
-
 // Basics
 
 export const BREAKPOINT = {
@@ -636,7 +635,7 @@ export const CHECKBOX: CSSPropertiesExtended = {
   },
 };
 
-export const COLLAPSABLE: CSSPropertiesExtended = {
+export const COLLAPSABLE: Record<BoxVariant & any, CSSPropertiesExtended> = {
   iconColor: {
     isOpen: 'brandMain',
     notOpen: 'gray.3',


### PR DESCRIPTION
_about **hasIconBg**: the Pinkish design doesn't have the bg._
![image](https://user-images.githubusercontent.com/6185507/130987977-0eced63d-ee61-40fc-9bf2-0907983593ef.png)
