### PR TITLE
Text: change props for consistency

### DIFF
--- a/src/components/InfoBox/InfoBox.tsx
+++ b/src/components/InfoBox/InfoBox.tsx
@@ -30,7 +30,7 @@ const Component = styled.div<Pick<InfoBoxProps, 'variant' | 'margin'>>(
   }),
 );
 
-const TitleText = styled(Text)`
+const TitleText: any = styled(Text)`
   font-size: 14px !important;
   font-weight: 500 !important;
 `;
@@ -65,7 +65,7 @@ const Title = ({
         color={color || 'brandMain'}
         bg="light"
       />
-      <TitleText variant="span" color={getColor()}>
+      <TitleText as="span" variant="b2m" color={getColor()}>
         {important ? title.toUpperCase() : title}
       </TitleText>
     </IconContainer>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -103,10 +103,10 @@ export const Input: FC<InputProps> = ({
   };
 
   return (
-    <Text variant="label" display="block" margin={margin}>
+    <Text as="label" variant="b2m" display="block" margin={margin}>
       {label && tooltip && (
         <Flex variant="raw" justify={tooltip ? 'spaced' : 'start'}>
-          <Text variant="span" format="b2m">
+          <Text as="span" variant="b2m">
             {label}
           </Text>
           {tooltip && <Tooltip variant="icon" content={tooltip} />}
@@ -132,7 +132,7 @@ export const Input: FC<InputProps> = ({
         {unit && <Unit>{unit}</Unit>}
       </InputWrapper>
       {error && (
-        <Text variant="span" format="b3" color="danger">
+        <Text as="span" variant="b3" color="danger">
           {error}
         </Text>
       )}

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,16 +1,16 @@
 import styled from 'styled-components';
-import { Icon, IconProps } from '../Icon';
-import { polyIcons } from '../../theme';
-import { Flex } from '../Flex';
-import { Text, TextProps } from '../Text';
-import { TextFormat } from '../../theme/types';
 
-const StyledAnchor = styled.a`
-  text-decoration: none;
-  :hover, :focus: {
-    text-decoration: none;
-  }
-`;
+import { polyIcons } from '../../theme';
+import { Icon, IconProps } from '../Icon';
+import { Flex } from '../Flex';
+import { Text, TextProps, TextVariant } from '../Text';
+
+const StyledAnchor = styled.a(() => ({
+  textDecoration: 'none',
+  ':hover, :focus': {
+    textDecoration: 'none',
+  },
+}));
 
 export type LinkProps = {
   href?: string;
@@ -35,15 +35,15 @@ const IconComponent = styled(Icon)<IconProps & { disabled: boolean }>(
 
 const sizeMap: Record<string, Record<string, string>> = {
   s: {
-    format: 'b3m',
+    variant: 'b3m',
     size: '12px',
   },
   m: {
-    format: 'b2m',
+    variant: 'b2m',
     size: '14px',
   },
   l: {
-    format: 'b1m',
+    variant: 'b1m',
     size: '16px',
   },
 };
@@ -60,8 +60,8 @@ export const Link = ({
   let component: any;
   const labelComponent = (
     <TextComponent
-      format={sizeMap[size].format as TextFormat}
-      variant="p"
+      variant={sizeMap[size].variant as TextVariant}
+      as="p"
       color={disabled ? 'gray3' : variant === 'primary' ? 'brandMain' : 'gray1'}
       disabled={disabled}
     >

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -24,7 +24,7 @@ export const IconStyled = styled(Icon)<
   },
 }));
 
-const StyledText = styled(Text)`
+const StyledText: any = styled(Text)`
   display: flex;
   align-items: center;
   cursor: pointer;
@@ -51,7 +51,7 @@ export const Radio: FC<Props> = (props) => {
   };
 
   return (
-    <StyledText variant="label">
+    <StyledText as="label" variant="b3">
       <HiddenRadio
         type="radio"
         name={name}
@@ -70,7 +70,8 @@ export const Radio: FC<Props> = (props) => {
       />
       <Text
         margin="0 5px"
-        variant="span"
+        as="span"
+        variant="b3"
         color={disabled ? 'gray2' : 'highlightText'}
       >
         {label}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -99,10 +99,10 @@ export const Select: FC<SelectProps> = ({
 
   return (
     <>
-      <Text variant="label" display="block" margin={margin}>
+      <Text as="label" variant="b2m" display="block" margin={margin}>
         {label && tooltip && (
           <Flex variant="raw" justify={tooltip ? 'spaced' : 'start'}>
-            <Text variant="span" format="b2m">
+            <Text as="span" variant="b2m">
               {label}
             </Text>
             {tooltip && <Tooltip variant="icon" content={tooltip} />}

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -79,11 +79,7 @@ const Item: FC<TabItemProps> = ({
               color={isActive ? 'gray.1' : 'gray.2'}
             />
           )}
-          <Text
-            variant="span"
-            format="b2m"
-            color={isActive ? 'gray.1' : 'gray.2'}
-          >
+          <Text as="span" variant="b2m" color={isActive ? 'gray.1' : 'gray.2'}>
             {text}
           </Text>
         </ActiveText>

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -41,7 +41,7 @@ export const Default = () => {
             accessor: 'did',
             footer: (index: number) =>
               index === 4 ? (
-                <Text variant="span" format="b3" color="red.0">
+                <Text as="span" variant="b3" color="red.0">
                   This identity (DID) is invalid. Please remove or edit the
                   address to continue
                 </Text>
@@ -152,7 +152,7 @@ export const Default = () => {
   ];
   const pageSizes = [5, 10, 20, 30];
   const title = (
-    <Text variant="span" format="b2m" color="gray.1">
+    <Text as="span" variant="b2m" color="gray.1">
       Table Demo
     </Text>
   );
@@ -231,7 +231,7 @@ export const Default = () => {
             />
           ),
           copy: (
-            <Text variant="span" format="b3" margin="m 0 0 0">
+            <Text as="span" variant="b3" margin="m 0 0 0">
               No Item Exist
             </Text>
           ),
@@ -354,7 +354,7 @@ export const TableExpandable = () => {
   ];
   const pageSizes = [5, 10, 20, 30];
   const title = (
-    <Text variant="span" format="b3">
+    <Text as="span" variant="b3">
       Table Expandable Demo
     </Text>
   );
@@ -406,7 +406,7 @@ export const TableExpandable = () => {
           />
         ),
         copy: (
-          <Text variant="span" format="b3" margin="m 0 0 0">
+          <Text as="span" variant="b3" margin="m 0 0 0">
             No Item Exist
           </Text>
         ),

--- a/src/components/Table/TableBasic.tsx
+++ b/src/components/Table/TableBasic.tsx
@@ -204,11 +204,12 @@ export function TableBasic({
                             column.getCustomHeaderProperties())}
                         >
                           <Text
-                            variant="span"
-                            format="b2m"
+                            as="span"
+                            variant="b2m"
                             color={column.isSorted ? 'brandMain' : 'gray.2'}
                           >
                             {column.render('Header')}
+                            {/* eslint-disable react/no-danger */}
                             <span
                               dangerouslySetInnerHTML={{
                                 __html: column.isSorted
@@ -218,6 +219,7 @@ export function TableBasic({
                                   : '',
                               }}
                             />
+                            {/* eslint-enable */}
                           </Text>
                         </sc.TableColumnHeader>
                       ),
@@ -307,7 +309,7 @@ export function TableBasic({
           {empty && empty.copy === false
             ? null
             : (empty && empty.copy) || (
-                <Text variant="span" color="gray2" margin="m 0 0 0">
+                <Text as="span" variant="b3" color="gray2" margin="m 0 0 0">
                   No data
                 </Text>
               )}

--- a/src/components/Table/TableBatchActions.tsx
+++ b/src/components/Table/TableBatchActions.tsx
@@ -46,7 +46,7 @@ export const TableBatchActions: FC<TableBatchActionsProps> = ({
                 key={`batchAction${index + 1}LastUpdate`}
                 margin="0 0 0 4px"
               >
-                <Text variant="span" format="b3" color="gray.1">
+                <Text as="span" variant="b3" color="gray.1">
                   {lastUpdate}
                 </Text>
               </Box>
@@ -72,7 +72,7 @@ export const TableBatchActions: FC<TableBatchActionsProps> = ({
                 )}
                 {action.buttonProps &&
                 action.buttonProps.variant === 'tertiary' ? (
-                  <Text variant="span" format="b2" color="brandMain">
+                  <Text as="span" variant="b2" color="brandMain">
                     {label(action.label)}
                   </Text>
                 ) : (

--- a/src/components/Table/TableEditableCell.tsx
+++ b/src/components/Table/TableEditableCell.tsx
@@ -70,8 +70,8 @@ export const TableEditableCell: FC<TableEditableCellProps> = ({
   ) : (
     <>
       <Text
-        variant="span"
-        format="b2"
+        as="span"
+        variant="b2"
         color="gray1"
         {...{ onClick: editCell }}
         {...(cell.column.editor ? { className: 'canEdit' } : {})}

--- a/src/components/Table/TablePagination.tsx
+++ b/src/components/Table/TablePagination.tsx
@@ -29,7 +29,7 @@ export const TablePagination: FC<TablePaginationProps> = ({
     <Flex variant="raw" justify="end">
       {pageSizes && setPageSize && (
         <Flex variant="raw" margin="0 xxl 0 0">
-          <Text variant="span" format="b2m" color="gray2">
+          <Text as="span" variant="b2m" color="gray2">
             {label}
           </Text>
           <Select
@@ -51,7 +51,7 @@ export const TablePagination: FC<TablePaginationProps> = ({
       )}
 
       <Box variant="raw" margin="0 xxl 0 0">
-        <Text variant="span" format="b2m" color="gray1">
+        <Text as="span" variant="b2m" color="gray1">
           {`${pageIndex * pageSize + 1}-${
             totalRows
               ? Math.min(totalRows, (pageIndex + 1) * pageSize)

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -14,7 +14,8 @@ const Template: Story<ComponentProps<typeof Text>> = (props: any) => (
 
 export const P = Template.bind({});
 P.args = {
-  variant: 'p',
+  variant: 'b2m',
+  as: 'p',
   children: (
     <>
       This is in a paragraph <span>with alt text</span>.
@@ -25,12 +26,14 @@ P.args = {
 
 export const Span = Template.bind({});
 Span.args = {
-  variant: 'span',
+  variant: 'b2',
+  as: 'span',
   children: 'This is in a span.',
 };
 
 export const Label = Template.bind({});
 Label.args = {
-  variant: 'label',
+  variant: 'b3',
+  as: 'label',
   children: 'This is in a label.',
 };

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,15 +1,28 @@
 import { FC } from 'react';
 import styled from 'styled-components';
 
-import { TextFormat, Display } from '../../theme/types';
+import { Display } from '../../theme/types';
 import { getMargin } from '../../theme/utils';
 
-export type TextVariant = 'p' | 'span' | 'label';
+export type TextAs = 'p' | 'span' | 'label';
+export type TextVariant =
+  | 'b1m'
+  | 'b1'
+  | 'b2m'
+  | 'b2'
+  | 'b3m'
+  | 'b3'
+  | 'c1'
+  | 'c2'
+  | 'btn'
+  | 'tn'
+  | 'code';
 
 export type TextProps = {
+  as: TextAs;
   variant: TextVariant;
   margin?: string;
-  format?: TextFormat;
+  padding?: string;
   color?: string;
   altColor?: string;
   display?: Display;
@@ -17,10 +30,21 @@ export type TextProps = {
 };
 
 const Component = styled.span<TextProps>(
-  ({ variant, format, margin, color, altColor, display, align, theme }) => ({
-    ...(theme.TEXT[variant] || {}),
-    ...(format ? theme.TYPOGRAPHY[format] : {}),
-    margin: getMargin({ theme, margin }),
+  ({
+    as,
+    variant,
+    margin,
+    padding,
+    color,
+    altColor,
+    display,
+    align,
+    theme,
+  }) => ({
+    ...(theme.TEXT[as] || {}),
+    ...(theme.TYPOGRAPHY[variant] || {}),
+    ...(margin ? { margin: getMargin({ theme, margin }) } : {}),
+    ...(padding ? { padding: getMargin({ theme, margin: padding }) } : {}),
     ...(color ? { color: theme.COLOR[color] } : {}),
     ...(altColor ? { span: { color: theme.COLOR[altColor] } } : {}),
     ...(display ? { display } : {}),
@@ -28,6 +52,4 @@ const Component = styled.span<TextProps>(
   }),
 );
 
-export const Text: FC<TextProps> = ({ variant, ...props }) => (
-  <Component as={variant} variant={variant} {...props} />
-);
+export const Text: FC<TextProps> = (props) => <Component {...props} />;

--- a/src/theme/definitions/blue.ts
+++ b/src/theme/definitions/blue.ts
@@ -5,7 +5,7 @@ import { CSSPropertiesExtended, Gap } from '../types';
 import { BoxVariant } from '../../components/Box';
 import { ButtonVariant } from '../../components/Button';
 import { IconVariant } from '../../components/Icon';
-import { TextVariant } from '../../components/Text';
+import { TextAs } from '../../components/Text';
 import { BadgeVariant } from '../../components/Badge';
 import { InfoBoxVariant } from '../../components/InfoBox';
 import { DrawerVariant } from '../../components/Drawer';
@@ -342,7 +342,7 @@ export const BOX: Record<BoxVariant, CSSPropertiesExtended> = {
   },
 };
 
-export const TEXT: Record<TextVariant, CSSPropertiesExtended> = {
+export const TEXT: Record<TextAs, CSSPropertiesExtended> = {
   p: {
     margin: `0 0 ${GAP.s} 0`,
     lineHeight: '27px',

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -12,19 +12,6 @@ export type Shadow = 'xs' | 's' | 'm' | 'l' | 'xl';
 
 export type Radius = 's' | 'm' | 'l' | 'xl';
 
-export type TextFormat =
-  | 'b1m'
-  | 'b1'
-  | 'b2m'
-  | 'b2'
-  | 'b3m'
-  | 'b3'
-  | 'c1'
-  | 'c2'
-  | 'btn'
-  | 'tn'
-  | 'code';
-
 export const propValueMap: Record<string, string> = {
   spaced: 'space-between',
   start: 'flex-start',


### PR DESCRIPTION
### Breaking change:
`Text` component now accepts `as` and `variant` as required props, instead of `variant` and `format`.
This makes replacing it with Polymesh UI easier since `variant` prop remains the same.
Blocks has been refactored to adapt the change (in this PR).

Once Blocks is updated in consuming projects, they'll need to be refactored:
- `<Text variant="p" format="b2m" />`
- `<Text as="p" variant="b2m" />`