### PR TITLE
refactor: infer type instead of `Record<string, string>`

### DIFF
--- a/src/theme/definitions/blue.ts
+++ b/src/theme/definitions/blue.ts
@@ -12,7 +12,7 @@ import { DrawerVariant } from '../../components/Drawer';
 
 // Basics
 
-export const BREAKPOINT: Record<string, number> = {
+export const BREAKPOINT = {
   xs: 320,
   sm: 768,
   md: 900,
@@ -20,7 +20,7 @@ export const BREAKPOINT: Record<string, number> = {
   xl: 1920,
 };
 
-export const MEDIA_QUERY: Record<string, string> = {
+export const MEDIA_QUERY = {
   xs: `@media (max-width: ${BREAKPOINT.xs}px)`,
   sm: `@media (min-width: ${BREAKPOINT.sm}px)`,
   md: `@media (min-width: ${BREAKPOINT.md}px)`,
@@ -38,7 +38,7 @@ export const GAP: Record<Gap, string> = {
   xxxl: '96px',
 };
 
-export const COLOR: Record<string, string> = {
+export const COLOR = {
   light: '#FFFFFF',
   gray1: '#1E1E1E',
   gray2: '#565656',

--- a/src/theme/definitions/pink.ts
+++ b/src/theme/definitions/pink.ts
@@ -5,7 +5,7 @@ import { InfoBoxVariant } from '../../components/InfoBox';
 
 import { CSSPropertiesExtended } from '../types';
 
-const COLOR: Record<string, string> = {
+const COLOR = {
   light: '#FFFFFF',
   gray1: '#1E1E1E',
   gray2: '#565656',


### PR DESCRIPTION
`Record<string, string>` does not allow IntelliSense to show specific object keys. However, it's possible through regular type inference.

I.e. this is made possible:
![image](https://user-images.githubusercontent.com/7417976/147162518-dfb49419-a9ba-432a-a408-f59a1a4a1e6b.png)
