### PR TITLE
fix: add react as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,7 @@
         "@tippyjs/react": "^4.2.5",
         "focus-visible": "^5.2.0",
         "moment": "^2.29.1",
-        "react": "^17.0.2",
         "react-day-picker": "^7.4.10",
-        "react-dom": "^17.0.2",
         "react-dropzone": "^14.2.3",
         "react-number-format": "^4.6.4",
         "react-select": "^4.3.1",
@@ -66,6 +64,10 @@
         "typescript": "^4.3.5",
         "webpack": "^5.65.0",
         "webpack-cli": "^4.9.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -31434,6 +31436,7 @@
     "node_modules/react": {
       "version": "17.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -31503,6 +31506,7 @@
     "node_modules/react-dom": {
       "version": "17.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -32899,6 +32903,7 @@
     "node_modules/scheduler": {
       "version": "0.20.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -60452,6 +60457,7 @@
     },
     "react": {
       "version": "17.0.2",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -60503,6 +60509,7 @@
     },
     "react-dom": {
       "version": "17.0.2",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -61547,6 +61554,7 @@
     },
     "scheduler": {
       "version": "0.20.2",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -34,9 +34,7 @@
     "@tippyjs/react": "^4.2.5",
     "focus-visible": "^5.2.0",
     "moment": "^2.29.1",
-    "react": "^17.0.2",
     "react-day-picker": "^7.4.10",
-    "react-dom": "^17.0.2",
     "react-dropzone": "^14.2.3",
     "react-number-format": "^4.6.4",
     "react-select": "^4.3.1",
@@ -88,5 +86,9 @@
     "typescript": "^4.3.5",
     "webpack": "^5.65.0",
     "webpack-cli": "^4.9.1"
+  },
+  "peerDependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   }
 }


### PR DESCRIPTION
This fixes conflicts with Next.js rendering. As a UI library, its react/react-dom should be declared as peer dependencies anyway.